### PR TITLE
Fix URL for zlib

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ new_http_archive(
 
 new_http_archive(
   name = "zlib_archive",
-  url = "http://zlib.net/zlib-1.2.10.tar.gz",
+  url = "http://zlib.net/fossils/zlib-1.2.10.tar.gz",
   sha256 = "8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017",
   strip_prefix = "zlib-1.2.10",
   build_file = "zlib.BUILD",

--- a/butteraugli/butteraugli_main.cc
+++ b/butteraugli/butteraugli_main.cc
@@ -276,7 +276,7 @@ void FromSrgbToLinear(const std::vector<Image8>& rgb,
 
 std::vector<Image8> ReadImageOrDie(const char* filename) {
   std::vector<Image8> rgb;
-  FILE* f = fopen(filename, "r");
+  FILE* f = fopen(filename, "rb");
   if (!f) {
     fprintf(stderr, "Cannot open %s\n", filename);
     exit(1);


### PR DESCRIPTION
Old versions are now kept in fossils folder , so now we won't have to update link for zlib so often