### PR TITLE
Fix MSVC compilation errors

### DIFF
--- a/butteraugli/butteraugli.cc
+++ b/butteraugli/butteraugli.cc
@@ -91,7 +91,7 @@ static inline bool IsNan(const double x) {
 
 static inline void CheckImage(const ImageF &image, const char *name) {
   for (size_t y = 0; y < image.ysize(); ++y) {
-    ConstRestrict<const float *> row = image.Row(y);
+    ConstRestrict<const float> row = image.Row(y);
     for (size_t x = 0; x < image.xsize(); ++x) {
       if (IsNan(row[x])) {
         printf("Image %s @ %lu,%lu (of %lu,%lu)\n", name, x, y, image.xsize(),
@@ -1214,7 +1214,7 @@ double ButteraugliScoreFromDiffmap(const ImageF& diffmap) {
   PROFILER_FUNC;
   float retval = 0.0f;
   for (size_t y = 0; y < diffmap.ysize(); ++y) {
-    ConstRestrict<const float *> row = diffmap.Row(y);
+    ConstRestrict<const float> row = diffmap.Row(y);
     for (size_t x = 0; x < diffmap.xsize(); ++x) {
       retval = std::max(retval, row[x]);
     }

--- a/butteraugli/butteraugli_main.cc
+++ b/butteraugli/butteraugli_main.cc
@@ -58,10 +58,10 @@ bool ReadPNG(FILE* f, std::vector<Image8>* rgb) {
     case 1: {
       // GRAYSCALE
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row = row_pointers[y];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(y);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(y);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(y);
+        ConstRestrict<const uint8_t> row = row_pointers[y];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(y);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(y);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(y);
 
         for (int x = 0; x < xsize; ++x) {
           const uint8_t gray = row[x];
@@ -74,11 +74,11 @@ bool ReadPNG(FILE* f, std::vector<Image8>* rgb) {
       // GRAYSCALE_ALPHA
       rgb->push_back(Image8(xsize, ysize));
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row = row_pointers[y];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(y);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(y);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(y);
-        ConstRestrict<uint8_t*> row3 = (*rgb)[3].Row(y);
+        ConstRestrict<const uint8_t> row = row_pointers[y];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(y);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(y);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(y);
+        ConstRestrict<uint8_t> row3 = (*rgb)[3].Row(y);
 
         for (int x = 0; x < xsize; ++x) {
           const uint8_t gray = row[2 * x + 0];
@@ -94,10 +94,10 @@ bool ReadPNG(FILE* f, std::vector<Image8>* rgb) {
     case 3: {
       // RGB
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row = row_pointers[y];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(y);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(y);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(y);
+        ConstRestrict<const uint8_t> row = row_pointers[y];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(y);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(y);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(y);
 
         for (int x = 0; x < xsize; ++x) {
           row0[x] = row[3 * x + 0];
@@ -111,11 +111,11 @@ bool ReadPNG(FILE* f, std::vector<Image8>* rgb) {
       // RGBA
       rgb->push_back(Image8(xsize, ysize));
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row = row_pointers[y];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(y);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(y);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(y);
-        ConstRestrict<uint8_t*> row3 = (*rgb)[3].Row(y);
+        ConstRestrict<const uint8_t> row = row_pointers[y];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(y);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(y);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(y);
+        ConstRestrict<uint8_t> row3 = (*rgb)[3].Row(y);
 
         for (int x = 0; x < xsize; ++x) {
           row0[x] = row[4 * x + 0];
@@ -187,10 +187,10 @@ bool ReadJPEG(FILE* f, std::vector<Image8>* rgb) {
       while (cinfo.output_scanline < cinfo.output_height) {
         jpeg_read_scanlines(&cinfo, buffer, 1);
 
-        ConstRestrict<const uint8_t*> row = buffer[0];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(cinfo.output_scanline - 1);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(cinfo.output_scanline - 1);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(cinfo.output_scanline - 1);
+        ConstRestrict<const uint8_t> row = buffer[0];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(cinfo.output_scanline - 1);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(cinfo.output_scanline - 1);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(cinfo.output_scanline - 1);
 
         for (int x = 0; x < xsize; x++) {
           const uint8_t gray = row[x];
@@ -203,10 +203,10 @@ bool ReadJPEG(FILE* f, std::vector<Image8>* rgb) {
       while (cinfo.output_scanline < cinfo.output_height) {
         jpeg_read_scanlines(&cinfo, buffer, 1);
 
-        ConstRestrict<const uint8_t*> row = buffer[0];
-        ConstRestrict<uint8_t*> row0 = (*rgb)[0].Row(cinfo.output_scanline - 1);
-        ConstRestrict<uint8_t*> row1 = (*rgb)[1].Row(cinfo.output_scanline - 1);
-        ConstRestrict<uint8_t*> row2 = (*rgb)[2].Row(cinfo.output_scanline - 1);
+        ConstRestrict<const uint8_t> row = buffer[0];
+        ConstRestrict<uint8_t> row0 = (*rgb)[0].Row(cinfo.output_scanline - 1);
+        ConstRestrict<uint8_t> row1 = (*rgb)[1].Row(cinfo.output_scanline - 1);
+        ConstRestrict<uint8_t> row2 = (*rgb)[2].Row(cinfo.output_scanline - 1);
 
         for (int x = 0; x < xsize; x++) {
           row0[x] = row[3 * x + 0];
@@ -240,8 +240,8 @@ void FromSrgbToLinear(const std::vector<Image8>& rgb,
     for (int c = 0; c < 3; c++) {
       linear.push_back(ImageF(xsize, ysize));
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row_rgb = rgb[c].Row(y);
-        ConstRestrict<float*> row_linear = linear[c].Row(y);
+        ConstRestrict<const uint8_t> row_rgb = rgb[c].Row(y);
+        ConstRestrict<float> row_linear = linear[c].Row(y);
         for (size_t x = 0; x < xsize; x++) {
           const int value = row_rgb[x];
           row_linear[x] = kSrgbToLinearTable[value];
@@ -252,9 +252,9 @@ void FromSrgbToLinear(const std::vector<Image8>& rgb,
     for (int c = 0; c < 3; c++) {
       linear.push_back(ImageF(xsize, ysize));
       for (int y = 0; y < ysize; ++y) {
-        ConstRestrict<const uint8_t*> row_rgb = rgb[c].Row(y);
-        ConstRestrict<float*> row_linear = linear[c].Row(y);
-        ConstRestrict<const uint8_t*> row_alpha = rgb[3].Row(y);
+        ConstRestrict<const uint8_t> row_rgb = rgb[c].Row(y);
+        ConstRestrict<float> row_linear = linear[c].Row(y);
+        ConstRestrict<const uint8_t> row_alpha = rgb[3].Row(y);
         for (size_t x = 0; x < xsize; x++) {
           int value;
           if (row_alpha[x] == 255) {


### PR DESCRIPTION
See https://developercommunity.visualstudio.com/content/problem/32196/msvc-cant-compile-a-templated-using-without-instan.html

I'm not sure if this the best workaround, as it changes technically public API in a header file.

However, we have the following message above:

```
// Implementation details, don't use anything below or your code will
// break in the future.
```

So I think this is fine