### PR TITLE
missing header

### DIFF
--- a/butteraugli/butteraugli_main.cc
+++ b/butteraugli/butteraugli_main.cc
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <vector>
+#include <algorithm>
 #include "butteraugli/butteraugli.h"
 
 extern "C" {


### PR DESCRIPTION
fails on windows msvc