### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ install corresponding `-dev` packages.
 The code is portable and also compiles on Windows after defining
 `_CRT_SECURE_NO_WARNINGS` in the project settings.
 
+## Building butteraugli - Using vcpkg
+
+You can download and install butteraugli using the [vcpkg](https://github.com/Microsoft/vcpkg) 
+dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install butteraugli
+
+The butteraugli port in vcpkg is kept up to date by Microsoft team members and community 
+contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) 
+on the vcpkg repository.
+
 ## Command-line utility {#cmdline-tool}
 
 Butteraugli, apart from the library, comes bundled with a comparison tool. The


### PR DESCRIPTION
Butteraugli is available as a port in vcpkg, a C++ library manager that simplifies installation for butteraugli and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build butteraugli, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.